### PR TITLE
[noissue] dependabot version strategy

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,7 @@ updates:
       time: "07:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 50
+    versioning-strategy: increase
   # Enable version updates for sample
   - package-ecosystem: "npm"
     directory: "/sample" # Location of package manifests
@@ -18,4 +19,4 @@ updates:
       time: "07:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 50
-    
+    versioning-strategy: increase


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/issues/6285

Dependabot should now bump the versions in the `package.json` files as well, rather than mostly (only?) bumping in the `yarn.lock`